### PR TITLE
Fix flag causing error at runtime

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@
 tdagent_major_version: 2
 
 # cleanup old plugins and configs
-td-agent_do_cleanup_old: yes
+tdagent_do_cleanup_old: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   with_items:
     - /etc/td-agent/conf.d
     - /etc/td-agent/plugin
-  when: td-agent_do_cleanup_old
+  when: tdagent_do_cleanup_old
 
 - name: set role variables, if necessary
   include: set-role-variables.yml


### PR DESCRIPTION
When running with current flag - getting following error 

```
TASK [fluentd : cleanup old configs and plugins] *******************************************************************************************************************************************************************************************************************************
task path: /Users/jerome/Workspaces/osmose-infra/ansible/roles/external/fluentd/tasks/main.yml:7
fatal: [XXX]: FAILED! => {"msg": "The conditional check 'td-agent_do_cleanup_old' failed. The error was: error while evaluating conditional (td-agent_do_cleanup_old): 'td' is undefined\n\nThe error appears to have been in '.../ansible/roles/external/fluentd/tasks/main.yml': line 7, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n#\n- name: cleanup old configs and plugins\n  ^ here\n"}
```

This fixes the issue - seems like somehow `-` is unsupported in var name